### PR TITLE
Fix notice in external header.php

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -130,7 +130,7 @@ register_shutdown_function(
         $time = array_key_exists('REQUEST_TIME', $_SERVER)
             ? $_SERVER['REQUEST_TIME']
             : time();
-        $requestTimeFloat = explode('.', $_SERVER['REQUEST_TIME_FLOAT']);
+        $requestTimeFloat = explode('.', str_replace(',', '.', strval($_SERVER['REQUEST_TIME_FLOAT'])));
         if (!isset($requestTimeFloat[1])) {
             $requestTimeFloat[1] = 0;
         }


### PR DESCRIPTION
I got this error in my french locale conf :

<b>Notice</b>:  A non well formed numeric value encountered in <b>/src/xhgui/external/header.php</b> on line <b>145</b><br />

It's because in french language, comma take place of dot when float converted in string.
